### PR TITLE
Add TidalProtocolUtils contract containing math utils & initial test

### DIFF
--- a/cadence/contracts/TidalProtocolUtils.cdc
+++ b/cadence/contracts/TidalProtocolUtils.cdc
@@ -1,0 +1,122 @@
+/// TidalProtocolUtils
+///
+/// This contract contains utility methods used by TidalProtocol
+///
+access(all) contract TidalProtocolUtils {
+
+    /**************
+     * MATH UTILS *
+     **************/
+
+    /// Raises the base to the power of the exponent
+    access(all) view fun pow(_ base: UInt256, to: UInt8): UInt256 {
+        if to == 0 {
+            return 1
+        }
+
+        var r = base
+        var exp: UInt8 = 1
+        while exp < to {
+            r = r * base
+            exp = exp + 1
+        }
+
+        return r
+    }
+
+    /// Raises the fixed point base to the power of the exponent
+    access(all) view fun ufixPow(_ base: UFix64, to: UInt8): UFix64 {
+        if to == 0 {
+            return 1.0
+        }
+
+        var r = base
+        var exp: UInt8 = 1
+        while exp < to {
+            r = r * base
+            exp = exp + 1
+        }
+
+        return r
+    }
+
+    /// Converts a UFix64 to a UInt256
+    access(all) view fun ufix64ToUInt256(_ value: UFix64, decimals: UInt8): UInt256 {
+        // Default to 10e8 scale, catching instances where decimals are less than default and scale appropriately
+        let ufixScaleExp: UInt8 = decimals < 8 ? decimals : 8
+        var ufixScale = self.ufixPow(10.0, to: ufixScaleExp)
+
+        // Separate the fractional and integer parts of the UFix64
+        let integer = UInt256(value)
+        var fractional = (value % 1.0) * ufixScale
+
+        // Calculate the multiplier for integer and fractional parts
+        var integerMultiplier: UInt256 = self.pow(10, to: decimals)
+        let fractionalMultiplierExp: UInt8 = decimals < 8 ? 0 : decimals - 8
+        var fractionalMultiplier: UInt256 = self.pow(10, to: fractionalMultiplierExp)
+
+        // Scale and sum the parts
+        return integer * integerMultiplier + UInt256(fractional) * fractionalMultiplier
+    }
+
+    /// Converts a UInt256 to a UFix64
+    access(all) view fun uint256ToUFix64(_ value: UInt256, decimals: UInt8): UFix64 {
+        // Calculate scale factors for the integer and fractional parts
+        let absoluteScaleFactor = self.pow(10, to: decimals)
+
+        // Separate the integer and fractional parts of the value
+        let scaledValue = value / absoluteScaleFactor
+        var fractional = value % absoluteScaleFactor
+        // Scale the fractional part
+        let scaledFractional = self.uint256FractionalToScaledUFix64Decimals(fractional, decimals: decimals)
+
+        // Ensure the parts do not exceed the max UFix64 value before conversion
+        assert(
+            scaledValue <= UInt256(UFix64.max),
+            message: "Scaled integer value \(value.toString()) exceeds max UFix64 value"
+        )
+        /// Check for the max value that can be converted to a UFix64 without overflowing
+        assert(
+            scaledValue == UInt256(UFix64.max) ? scaledFractional < 0.09551616 : true,
+            message: "Scaled integer value \(value.toString()) exceeds max UFix64 value"
+        )
+
+        return UFix64(scaledValue) + scaledFractional
+    }
+
+    /// Converts a UInt256 fractional value with the given decimal places to a scaled UFix64. Note that UFix64 has
+    /// decimal precision of 8 places so converted values may lose precision and be rounded down.
+    access(all) view fun uint256FractionalToScaledUFix64Decimals(_ value: UInt256, decimals: UInt8): UFix64 {
+        pre {
+            self.getNumberOfDigits(value) <= decimals: "Fractional digits exceed the defined decimal places"
+        }
+        post {
+            result < 1.0: "Resulting scaled fractional exceeds 1.0"
+        }
+
+        var fractional = value
+        // Truncate fractional to the first 8 decimal places which is the max precision for UFix64
+        if decimals >= 8 {
+            fractional = fractional / self.pow(10, to: decimals - 8)
+        }
+        // Return early if the truncated fractional part is now 0
+        if fractional == 0 {
+            return 0.0
+        }
+
+        // Scale the fractional part
+        let fractionalMultiplier = self.ufixPow(0.1, to: decimals < 8 ? decimals : 8)
+        return UFix64(fractional) * fractionalMultiplier
+    }
+
+    /// Returns the number of digits in the given UInt256
+    access(all) view fun getNumberOfDigits(_ value: UInt256): UInt8 {
+        var tmp = value
+        var digits: UInt8 = 0
+        while tmp > 0 {
+            tmp = tmp / 10
+            digits = digits + 1
+        }
+        return digits
+    }
+}

--- a/cadence/tests/scripts/uint256_to_ufix64.cdc
+++ b/cadence/tests/scripts/uint256_to_ufix64.cdc
@@ -1,0 +1,6 @@
+import "TidalProtocolUtils"
+
+access(all)
+fun main(value: UInt256, decimals: UInt8): UFix64 {
+    return TidalProtocolUtils.uint256ToUFix64(value, decimals: decimals)
+}

--- a/cadence/tests/test_helpers.cdc
+++ b/cadence/tests/test_helpers.cdc
@@ -49,6 +49,12 @@ fun deployContracts() {
     Test.expect(err, Test.beNil())
 
     err = Test.deployContract(
+        name: "TidalProtocolUtils",
+        path: "../contracts/TidalProtocolUtils.cdc",
+        arguments: []
+    )
+    Test.expect(err, Test.beNil())
+    err = Test.deployContract(
         name: "TidalProtocol",
         path: "../contracts/TidalProtocol.cdc",
         arguments: []

--- a/cadence/tests/utils_test.cdc
+++ b/cadence/tests/utils_test.cdc
@@ -1,0 +1,186 @@
+import Test
+import BlockchainHelpers
+
+import "test_helpers.cdc"
+
+import "TidalProtocolUtils"
+
+access(all) let protocolAccount = Test.getAccount(0x0000000000000007)
+
+access(all)
+fun setup() {
+    deployContracts()
+}
+
+access(all)
+fun testReducedPrecisionUInt256ToUFix64Succeeds() {
+    let uintAmount: UInt256 = 24_244_814_054_591
+    let ufixAmount: UFix64 = 24_244_814.05459100
+
+    let actualUFixAmount = TidalProtocolUtils.uint256ToUFix64(uintAmount, decimals: 6)
+    Test.assertEqual(ufixAmount, actualUFixAmount)
+}
+
+access(all)
+fun testReducedPrecisionUInt256SmallChangeToUFix64Succeeds() {
+    let uintAmount: UInt256 = 24_244_814_000_020
+    let ufixAmount: UFix64 = 24_244_814.000020
+
+    let actualUFixAmount = TidalProtocolUtils.uint256ToUFix64(uintAmount, decimals: 6)
+    Test.assertEqual(ufixAmount, actualUFixAmount)
+}
+
+// Converting from UFix64 to UInt256 with reduced point precision (6 vs. 8) should round down
+access(all)
+fun testReducedPrecisionUFix64ToUInt256Succeeds() {
+    let uintAmount: UInt256 = 24_244_814_054_591
+    let ufixAmount: UFix64 = 24_244_814.05459154
+
+    let actualUIntAmount = TidalProtocolUtils.ufix64ToUInt256(ufixAmount, decimals: 6)
+    Test.assertEqual(uintAmount, actualUIntAmount)
+}
+
+access(all)
+fun testDustUInt256ToUFix64Succeeds() {
+    let dustUFixAmount: UFix64 = 0.00002547
+    let dustUIntAmount: UInt256 = 25_470_000_000_000
+
+    let actualUFixAmount = TidalProtocolUtils.uint256ToUFix64(dustUIntAmount, decimals: 18)
+    Test.assertEqual(dustUFixAmount, actualUFixAmount)
+    Test.assert(actualUFixAmount > 0.0)
+}
+
+access(all)
+fun testDustUFix64ToUInt256Succeeds() {
+    let dustUFixAmount: UFix64 = 0.00002547
+    let dustUIntAmount: UInt256 = 25_470_000_000_000
+
+    let actualUIntAmount = TidalProtocolUtils.ufix64ToUInt256(dustUFixAmount, decimals: 18)
+    Test.assertEqual(dustUIntAmount, actualUIntAmount)
+    Test.assert(actualUIntAmount > 0)
+}
+
+access(all)
+fun testZeroUInt256ToUFix64Succeeds() {
+    let zeroUFixAmount: UFix64 = 0.0
+    let zeroUIntAmount: UInt256 = 0
+
+    let actualUFixAmount = TidalProtocolUtils.uint256ToUFix64(zeroUIntAmount, decimals: 18)
+    Test.assertEqual(zeroUFixAmount, actualUFixAmount)
+}
+
+access(all)
+fun testZeroUFix64ToUInt256Succeeds() {
+    let zeroUFixAmount: UFix64 = 0.0
+    let zeroUIntAmount: UInt256 = 0
+
+    let actualUIntAmount = TidalProtocolUtils.ufix64ToUInt256(zeroUFixAmount, decimals: 18)
+    Test.assertEqual(zeroUIntAmount, actualUIntAmount)
+}
+
+access(all)
+fun testNonFractionalUInt256ToUFix64Succeeds() {
+    let nonFractionalUFixAmount: UFix64 = 100.0
+    let nonFractionalUIntAmount: UInt256 = 100_000_000_000_000_000_000
+
+    let actualUFixAmount = TidalProtocolUtils.uint256ToUFix64(nonFractionalUIntAmount, decimals: 18)
+    Test.assertEqual(nonFractionalUFixAmount, actualUFixAmount)
+}
+
+access(all)
+fun testNonFractionalUFix64ToUInt256Succeeds() {
+    let nonFractionalUFixAmount: UFix64 = 100.0
+    let nonFractionalUIntAmount: UInt256 = 100_000_000_000_000_000_000
+
+    let actualUIntAmount = TidalProtocolUtils.ufix64ToUInt256(nonFractionalUFixAmount, decimals: 18)
+    Test.assertEqual(nonFractionalUIntAmount, actualUIntAmount)
+}
+
+access(all)
+fun testLargeFractionalUInt256ToUFix64Succeeds() {
+    let largeFractionalUFixAmount: UFix64 = 1.99785982
+    let largeFractionalUIntAmount: UInt256 = 1_997_859_829_999_999_999
+
+    let actualUFixAmount = TidalProtocolUtils.uint256ToUFix64(largeFractionalUIntAmount, decimals: 18)
+    Test.assertEqual(largeFractionalUFixAmount, actualUFixAmount)
+}
+
+access(all)
+fun testLargeFractionalTrailingZerosUInt256ToUFix64Succeeds() {
+    let largeFractionalUFixAmount: UFix64 = 1.99785982
+    let largeFractionalUIntAmount: UInt256 = 1_997_859_829_999_000_000
+
+    let actualUFixAmount = TidalProtocolUtils.uint256ToUFix64(largeFractionalUIntAmount, decimals: 18)
+    Test.assertEqual(largeFractionalUFixAmount, actualUFixAmount)
+}
+
+access(all)
+fun testLargeFractionalUFix64ToUInt256Succeeds() {
+    let largeFractionalUFixAmount: UFix64 = 1.99785982
+    let largeFractionalUIntAmount: UInt256 = 1_997_859_820_000_000_000
+
+    let actualUIntAmount = TidalProtocolUtils.ufix64ToUInt256(largeFractionalUFixAmount, decimals: 18)
+    Test.assertEqual(largeFractionalUIntAmount, actualUIntAmount)
+}
+
+access(all)
+fun testIntegerAndLeadingZeroFractionalUInt256ToUFix64Succeeds() {
+    let ufixAmount: UFix64 = 100.00000500
+    let uintAmount: UInt256 = 100_000_005_000_000_888_999
+
+    let actualUFixAmount = TidalProtocolUtils.uint256ToUFix64(uintAmount, decimals: 18)
+    Test.assertEqual(ufixAmount, actualUFixAmount)
+}
+
+access(all)
+fun testIntegerAndLeadingZeroFractionalUFix64ToUInt256Succeeds() {
+    let ufixAmount: UFix64 = 100.00000500
+    let uintAmount: UInt256 = 100_000_005_000_000_000_000
+
+    let actualUIntAmount = TidalProtocolUtils.ufix64ToUInt256(ufixAmount, decimals: 18)
+    Test.assertEqual(uintAmount, actualUIntAmount)
+}
+
+access(all)
+fun testMaxUFix64ToUInt256Succeeds() {
+    let ufixAmount: UFix64 = UFix64.max
+    let uintAmount: UInt256 = 184467440737_095516150000000000
+
+    let actualUIntAmount = TidalProtocolUtils.ufix64ToUInt256(ufixAmount, decimals: 18)
+
+    Test.assertEqual(uintAmount, actualUIntAmount)
+}
+
+access(all)
+fun testMaxUFix64AsUInt256ToUFix64Succeds() {
+    let ufixAmount: UFix64 = UFix64.max
+    var uintAmount: UInt256 = 184467440737_095516150000000000
+
+    let actualUFixAmount = TidalProtocolUtils.uint256ToUFix64(uintAmount, decimals: 18)
+
+    Test.assertEqual(ufixAmount, actualUFixAmount)
+}
+
+access(all)
+fun testFractionalPartMaxUFix64AsUInt256ToUFix64Fails() {
+    let ufixAmount: UFix64 = UFix64.max
+    var uintAmount: UInt256 = 184467440737_095_516_150_000_000_000 + 10_000_000_000
+
+    let convertedResult = executeScript(
+        "./scripts/uint256_to_ufix64.cdc",
+        [uintAmount, UInt8(18)]
+    )
+    Test.expect(convertedResult, Test.beFailed())
+}
+
+access(all)
+fun testIntegerPartMaxUFix64AsUInt256ToUFix64Fails() {
+    let ufixAmount: UFix64 = UFix64.max
+    var uintAmount: UInt256 = 184467440737_095_516_150_000_000_000 + 100_000_000_000_000_000_000_000
+
+    let convertedResult = executeScript(
+        "./scripts/uint256_to_ufix64.cdc",
+        [uintAmount, UInt8(18)]
+    )
+    Test.expect(convertedResult, Test.beFailed())
+}

--- a/flow.json
+++ b/flow.json
@@ -42,6 +42,12 @@
 				"testing": "0x0000000000000007"
 			}
 		},
+		"TidalProtocolUtils": {
+			"source": "./cadence/contracts/TidalProtocolUtils.cdc",
+			"aliases": {
+				"testing": "0x0000000000000007"
+			}
+		},
 		"MOET": {
 			"source": "./cadence/contracts/MOET.cdc",
 			"aliases": {
@@ -137,6 +143,7 @@
 			"emulator-account": [
 				"DFBUtils",
 				"DFB",
+				"TidalProtocolUtils",
 				"TidalProtocol",
 				"MOET"
 			]


### PR DESCRIPTION
### Description

The contents of this PR are ported from [FlowEVMBridgeUtils](https://github.com/onflow/flow-evm-bridge/blob/main/cadence/contracts/bridge/FlowEVMBridgeUtils.cdc) including the new TidalProtocolUtils as well as conversion tests. These are included in anticipation of subsequent changes addressing insufficient decimal precision served by UFix64 in the TidalProtocol contract.