### PR TITLE
Split liquidation pausing and unpausing into separate functions

### DIFF
--- a/cadence/contracts/FlowCreditMarket.cdc
+++ b/cadence/contracts/FlowCreditMarket.cdc
@@ -2962,20 +2962,30 @@ access(all) contract FlowCreditMarket {
             }
         }
 
-        /// Pauses or unpauses liquidations; when unpausing, starts a warm-up window
-        access(EGovernance) fun pauseLiquidations(flag: Bool) {
-            if flag {
-                self.liquidationsPaused = true
-                emit LiquidationsPaused(poolUUID: self.uuid)
-            } else {
-                self.liquidationsPaused = false
-                let now = UInt64(getCurrentBlock().timestamp)
-                self.lastUnpausedAt = now
-                emit LiquidationsUnpaused(
-                    poolUUID: self.uuid,
-                    warmupEndsAt: now + self.liquidationWarmupSec
-                )
+        /// Pauses liquidations
+        access(EGovernance) fun pauseLiquidations() {
+            if self.liquidationsPaused {
+                return
             }
+            self.liquidationsPaused = true
+
+            emit LiquidationsPaused(poolUUID: self.uuid)
+        }
+
+        /// Unpauses liquidations, starting the warmup period
+        access(EGovernance) fun unpauseLiquidations() {
+            if !self.liquidationsPaused {
+                return
+            }
+            self.liquidationsPaused = false
+
+            let now = UInt64(getCurrentBlock().timestamp)
+            self.lastUnpausedAt = now
+
+            emit LiquidationsUnpaused(
+                poolUUID: self.uuid,
+                warmupEndsAt: now + self.liquidationWarmupSec
+            )
         }
 
         /// Adds a new token type to the pool with the given parameters defining borrowing limits on collateral,


### PR DESCRIPTION
## Description

Avoid boolean flags and just have two separate functions.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/FlowALP/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 