### PR TITLE
Add tests for external oracles (Band & IncrementFi)

### DIFF
--- a/cadence/tests/external_oracle_test.cdc
+++ b/cadence/tests/external_oracle_test.cdc
@@ -1,0 +1,93 @@
+#test_fork(network: "mainnet", height: nil)
+
+import Test
+
+import "FlowToken"
+import "MOET"
+import "EVMVMBridgedToken_99af3eea856556646c98c8b9b2548fe815240750" // PYUSD0
+
+access(all) let PYUSD0VaultType = Type<@EVMVMBridgedToken_99af3eea856556646c98c8b9b2548fe815240750.Vault>()
+
+access(all) fun setup() {
+    var err: Test.Error? = nil
+
+    // TODO(holyfuchs):
+    // remove this once this is deployed to mainnet: holyfuchs/incrementfi-price-oracle
+    err = Test.deployContract(
+        name: "IncrementFiSwapConnectors",
+        path: "../../FlowActions/cadence/contracts/connectors/increment-fi/IncrementFiSwapConnectors.cdc",
+        arguments: []
+    )
+    Test.expect(err, Test.beNil())
+}
+
+access(all) fun test_band() {
+    let feeAccount = Test.createAccount()
+    let txn = Test.Transaction(
+        code: Test.readFile("transactions/external_oracle/create_band_empty_fee.cdc"),
+        authorizers: [feeAccount.address],
+        signers: [feeAccount],
+        arguments: [Type<@MOET.Vault>()]
+    )
+    let result = Test.executeTransaction(txn)
+    Test.expect(result, Test.beSucceeded())
+
+    let unitScriptResult = Test.executeScript(
+        Test.readFile("scripts/external_oracle/band_unit_of_account.cdc"),
+        [feeAccount.address]
+    )
+    Test.expect(unitScriptResult, Test.beSucceeded())
+    let unitId = unitScriptResult.returnValue! as! String?
+    log(unitId)
+    Test.assert(unitId != nil, message: "expected unitOfAccount identifier")
+    Test.assert(unitId!.length > 0, message: "expected non-empty unitOfAccount")
+}
+
+access(all) fun test_band_price() {
+    let feeAccount = Test.createAccount()
+    let txn = Test.Transaction(
+        code: Test.readFile("transactions/external_oracle/create_band_empty_fee.cdc"),
+        authorizers: [feeAccount.address],
+        signers: [feeAccount],
+        arguments: [Type<@MOET.Vault>()]
+    )
+    Test.expect(Test.executeTransaction(txn), Test.beSucceeded())
+
+    let priceScriptResult = Test.executeScript(
+        Test.readFile("scripts/external_oracle/band_price.cdc"),
+        [feeAccount.address, Type<@FlowToken.Vault>()]
+    )
+    Test.expect(priceScriptResult, Test.beSucceeded())
+    let price = priceScriptResult.returnValue as! UFix64?
+    log(price)
+    Test.assert(price != nil, message: "expected price, got nil")
+}
+
+access(all) fun test_increment_fi() {
+    let flowKey = String.join(Type<@FlowToken.Vault>().identifier.split(separator: ".").slice(from: 0, upTo: 3), separator: ".")
+    let moetKey = String.join(Type<@MOET.Vault>().identifier.split(separator: ".").slice(from: 0, upTo: 3), separator: ".")
+    let path = [flowKey, moetKey]
+    let unitScriptResult = Test.executeScript(
+        Test.readFile("scripts/external_oracle/increment_fi_unit_of_account.cdc"),
+        [Type<@MOET.Vault>(), Type<@FlowToken.Vault>(), path]
+    )
+    Test.expect(unitScriptResult, Test.beSucceeded())
+    let unitId = unitScriptResult.returnValue! as! String?
+    Test.assert(unitId != nil, message: "expected unitOfAccount identifier")
+    Test.assert(unitId!.length > 0, message: "expected non-empty unitOfAccount")
+}
+
+access(all) fun test_increment_fi_price() {
+    let flowKey = String.join(Type<@FlowToken.Vault>().identifier.split(separator: ".").slice(from: 0, upTo: 3), separator: ".")
+    let pyusd0Key = String.join(PYUSD0VaultType.identifier.split(separator: ".").slice(from: 0, upTo: 3), separator: ".")
+    let path = [flowKey, pyusd0Key]
+    let priceScriptResult = Test.executeScript(
+        Test.readFile("scripts/external_oracle/increment_fi_price.cdc"),
+        [PYUSD0VaultType, Type<@FlowToken.Vault>(), path]
+    )
+    Test.expect(priceScriptResult, Test.beSucceeded())
+    let price = priceScriptResult.returnValue as! UFix64?
+    log(price)
+    Test.assert(price != nil, message: "expected price when pair exists")
+}
+

--- a/cadence/tests/scripts/external_oracle/band_price.cdc
+++ b/cadence/tests/scripts/external_oracle/band_price.cdc
@@ -1,0 +1,12 @@
+import "DeFiActions"
+
+/// Borrows the Band oracle as DeFiActions.PriceOracle at
+/// /public/bandOraclePriceOracle (created by create_band_empty_fee.cdc)
+/// and returns the price of the given token type.
+access(all) fun main(ownerAddress: Address, ofToken: Type): UFix64? {
+    let oracleRef = getAccount(ownerAddress).capabilities.borrow<&{DeFiActions.PriceOracle}>(/public/bandOraclePriceOracle)
+    if oracleRef == nil {
+        return nil
+    }
+    return oracleRef!.price(ofToken: ofToken)
+}

--- a/cadence/tests/scripts/external_oracle/band_unit_of_account.cdc
+++ b/cadence/tests/scripts/external_oracle/band_unit_of_account.cdc
@@ -1,0 +1,12 @@
+import "DeFiActions"
+
+/// Borrows the Band oracle as DeFiActions.PriceOracle at
+/// /public/bandOraclePriceOracle (created by create_band_empty_fee.cdc)
+/// and returns the unitOfAccount type identifier.
+access(all) fun main(ownerAddress: Address): String? {
+    let oracleRef = getAccount(ownerAddress).capabilities.borrow<&{DeFiActions.PriceOracle}>(/public/bandOraclePriceOracle)
+    if oracleRef == nil {
+        return nil
+    }
+    return oracleRef!.unitOfAccount().identifier
+}

--- a/cadence/tests/scripts/external_oracle/increment_fi_price.cdc
+++ b/cadence/tests/scripts/external_oracle/increment_fi_price.cdc
@@ -1,0 +1,15 @@
+import "DeFiActions"
+import "IncrementFiSwapConnectors"
+
+/// Builds a DeFiActions.PriceOracle using IncrementFiSwapConnectors.PriceOracle
+/// and returns price(ofToken: FLOW).
+access(all) fun main(unitOfAccount: Type, baseToken: Type, path: [String]): UFix64? {
+    let oracle = IncrementFiSwapConnectors.PriceOracle(
+        unitOfAccount: unitOfAccount,
+        baseToken: baseToken,
+        path: path,
+        uniqueID: nil
+    )
+    let price = oracle.price(ofToken: baseToken)
+    return price
+}

--- a/cadence/tests/scripts/external_oracle/increment_fi_unit_of_account.cdc
+++ b/cadence/tests/scripts/external_oracle/increment_fi_unit_of_account.cdc
@@ -1,0 +1,16 @@
+import "DeFiActions"
+import "FlowToken"
+import "USDCFlow"
+import "IncrementFiSwapConnectors"
+
+/// Builds a DeFiActions.PriceOracle using IncrementFiSwapConnectors.PriceOracle
+/// and returns the unitOfAccount identifier
+access(all) fun main(unitOfAccount: Type, baseToken: Type, path: [String]): String? {
+    let oracle = IncrementFiSwapConnectors.PriceOracle(
+        unitOfAccount: unitOfAccount,
+        baseToken: baseToken,
+        path: path,
+        uniqueID: nil
+    )
+    return oracle.unitOfAccount().identifier
+}

--- a/cadence/tests/transactions/external_oracle/create_band_empty_fee.cdc
+++ b/cadence/tests/transactions/external_oracle/create_band_empty_fee.cdc
@@ -1,0 +1,29 @@
+import "FungibleToken"
+import "FlowToken"
+import "FungibleTokenConnectors"
+import "BandOracleConnectors"
+
+/// Creates a BandOracleConnectors.PriceOracle with the given unitOfAccount and
+/// an empty FlowToken vault as the fee source, saves it to storage, and
+/// publishes a capability at /public/bandOraclePriceOracle
+transaction(unitOfAccount: Type) {
+    prepare(signer: auth(BorrowValue, SaveValue, Capabilities, IssueStorageCapabilityController, PublishCapability) &Account) {
+        let flowTokenAccount = getAccount(Type<@FlowToken.Vault>().address!)
+        let flowTokenRef = flowTokenAccount.contracts.borrow<&{FungibleToken}>(name: "FlowToken")
+            ?? panic("FlowToken contract not found")
+        let emptyVault <- flowTokenRef.createEmptyVault(vaultType: Type<@FlowToken.Vault>())
+        signer.storage.save(<-emptyVault, to: /storage/flowFeeVault)
+
+        let cap = signer.capabilities.storage.issue<auth(FungibleToken.Withdraw) &{FungibleToken.Vault}>(/storage/flowFeeVault)
+        let feeSource = FungibleTokenConnectors.VaultSource(min: nil, withdrawVault: cap, uniqueID: nil)
+        let oracle = BandOracleConnectors.PriceOracle(
+            unitOfAccount: unitOfAccount,
+            staleThreshold: 3600,
+            feeSource: feeSource,
+            uniqueID: nil
+        )
+        signer.storage.save(oracle, to: /storage/bandOraclePriceOracle)
+        let oracleCap = signer.capabilities.storage.issue<&BandOracleConnectors.PriceOracle>(/storage/bandOraclePriceOracle)
+        signer.capabilities.publish(oracleCap, at: /public/bandOraclePriceOracle)
+    }
+}

--- a/flow.json
+++ b/flow.json
@@ -12,34 +12,6 @@
 				"testing": "0000000000000008"
 			}
 		},
-		"BandOracleConnectors": {
-			"source": "./FlowActions/cadence/contracts/connectors/band-oracle/BandOracleConnectors.cdc",
-			"aliases": {
-				"emulator": "045a1763c93006ca",
-				"mainnet": "e36ef556b8b5d955",
-				"mainnet-fork": "e36ef556b8b5d955",
-				"testing": "0000000000000006",
-				"testnet": "bb76ea2f8aad74a0"
-			}
-		},
-		"DeFiActions": {
-			"source": "./FlowActions/cadence/contracts/interfaces/DeFiActions.cdc",
-			"aliases": {
-				"mainnet": "6d888f175c158410",
-				"mainnet-fork": "6d888f175c158410",
-				"testing": "0000000000000006",
-				"testnet": "0b11b1848a8aa2c0"
-			}
-		},
-		"DeFiActionsUtils": {
-			"source": "./FlowActions/cadence/contracts/utils/DeFiActionsUtils.cdc",
-			"aliases": {
-				"mainnet": "6d888f175c158410",
-				"mainnet-fork": "6d888f175c158410",
-				"testing": "0000000000000006",
-				"testnet": "0b11b1848a8aa2c0"
-			}
-		},
 		"DummyConnectors": {
 			"source": "./cadence/contracts/mocks/DummyConnectors.cdc",
 			"aliases": {
@@ -89,6 +61,7 @@
 		"MOET": {
 			"source": "./cadence/contracts/MOET.cdc",
 			"aliases": {
+				"mainnet": "6b00ff876c299c61",
 				"testing": "0000000000000007"
 			}
 		},
@@ -114,10 +87,28 @@
 		}
 	},
 	"dependencies": {
+		"BandOracle": {
+			"source": "mainnet://6801a6222ebf784a.BandOracle",
+			"hash": "ababa195ef50b63d71520022aa2468656a9703b924c0f5228cfaa51a71db094d",
+			"block_height": 143487068,
+			"aliases": {
+				"mainnet": "6801a6222ebf784a",
+				"mainnet-fork": "6801a6222ebf784a"
+			}
+		},
+		"BandOracleConnectors": {
+			"source": "mainnet://e36ef556b8b5d955.BandOracleConnectors",
+			"hash": "0bb4d8014bb2b195a25004cf9221e29857f12828bff6e7efc02b781debdee07a",
+			"block_height": 143487218,
+			"aliases": {
+				"mainnet": "e36ef556b8b5d955",
+				"mainnet-fork": "e36ef556b8b5d955"
+			}
+		},
 		"Burner": {
 			"source": "mainnet://f233dcee88fe0abe.Burner",
 			"hash": "71af18e227984cd434a3ad00bb2f3618b76482842bae920ee55662c37c8bf331",
-			"block_height": 139085361,
+			"block_height": 143487068,
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "f233dcee88fe0abe",
@@ -125,10 +116,50 @@
 				"testnet": "9a0766d93b6608b7"
 			}
 		},
+		"CrossVMMetadataViews": {
+			"source": "mainnet://1d7e57aa55817448.CrossVMMetadataViews",
+			"hash": "7e79b77b87c750de5b126ebd6fca517c2b905ac7f01c0428e9f3f82838c7f524",
+			"block_height": 143895185,
+			"aliases": {}
+		},
+		"CrossVMNFT": {
+			"source": "mainnet://1e4aa0b87d10b141.CrossVMNFT",
+			"hash": "8fe69f487164caffedab68b52a584fa7aa4d54a0061f4f211998c73a619fbea5",
+			"block_height": 143895185,
+			"aliases": {}
+		},
+		"CrossVMToken": {
+			"source": "mainnet://1e4aa0b87d10b141.CrossVMToken",
+			"hash": "9f055ad902e7de5619a2b0f2dc91826ac9c4f007afcd6df9f5b8229c0ca94531",
+			"block_height": 143895185,
+			"aliases": {}
+		},
+		"DeFiActions": {
+			"source": "mainnet://6d888f175c158410.DeFiActions",
+			"hash": "2a171eb1445c6f22f7eb8b19da21ad6ff34ae99add13c7cd096e3602ea3bbd92",
+			"block_height": 143487419,
+			"aliases": {
+				"mainnet": "6d888f175c158410",
+				"mainnet-fork": "6d888f175c158410",
+				"testing": "0000000000000006",
+				"testnet": "0b11b1848a8aa2c0"
+			}
+		},
+		"DeFiActionsUtils": {
+			"source": "mainnet://6d888f175c158410.DeFiActionsUtils",
+			"hash": "f3ee7f02ec7373742172f08302471f7b16c44fc0e8deba1efeb50b4367610224",
+			"block_height": 143487419,
+			"aliases": {
+				"mainnet": "6d888f175c158410",
+				"mainnet-fork": "6d888f175c158410",
+				"testing": "0000000000000006",
+				"testnet": "0b11b1848a8aa2c0"
+			}
+		},
 		"EVM": {
 			"source": "mainnet://e467b9dd11fa00df.EVM",
 			"hash": "960b0c7df7ee536956af196fba8c8d5dd4f7a89a4ecc61467e31287c4617b0dd",
-			"block_height": 141019535,
+			"block_height": 143487068,
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "e467b9dd11fa00df",
@@ -136,10 +167,19 @@
 				"testnet": "8c5303eaa26202d6"
 			}
 		},
+		"EVMVMBridgedToken_99af3eea856556646c98c8b9b2548fe815240750": {
+			"source": "mainnet://1e4aa0b87d10b141.EVMVMBridgedToken_99af3eea856556646c98c8b9b2548fe815240750",
+			"hash": "c277e799d149a9ff85e9132f5b202e1a3caeef429f2cd0f9ce01f3f86cc52e11",
+			"block_height": 143895185,
+			"aliases": {
+				"mainnet": "1e4aa0b87d10b141",
+				"mainnet-fork": "1e4aa0b87d10b141"
+			}
+		},
 		"FlowCron": {
 			"source": "mainnet://6dec6e64a13b881e.FlowCron",
 			"hash": "ab570aabfb4d3ee01537ad85ad789ed13ac193ba447bc037365d51d748272cd5",
-			"block_height": 141024643,
+			"block_height": 143487068,
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "6dec6e64a13b881e",
@@ -151,7 +191,7 @@
 		"FlowCronUtils": {
 			"source": "mainnet://6dec6e64a13b881e.FlowCronUtils",
 			"hash": "498c32c1345b9b1db951a18e4ea94325b8c9c05ea691f2d9b6af75b886ab51a2",
-			"block_height": 141024643,
+			"block_height": 143487068,
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "6dec6e64a13b881e",
@@ -160,10 +200,70 @@
 				"testnet": "5cbfdec870ee216d"
 			}
 		},
+		"FlowEVMBridge": {
+			"source": "mainnet://1e4aa0b87d10b141.FlowEVMBridge",
+			"hash": "9cd0f897b19c0394e9042225e5758d6ae529a0cce19b19ae05bde8e0f14aa10b",
+			"block_height": 143895185,
+			"aliases": {}
+		},
+		"FlowEVMBridgeConfig": {
+			"source": "mainnet://1e4aa0b87d10b141.FlowEVMBridgeConfig",
+			"hash": "3c09f74467f22dac7bc02b2fdf462213b2f8ddfb513cd890ad0c2a7016507be3",
+			"block_height": 143895185,
+			"aliases": {}
+		},
+		"FlowEVMBridgeCustomAssociationTypes": {
+			"source": "mainnet://1e4aa0b87d10b141.FlowEVMBridgeCustomAssociationTypes",
+			"hash": "4651183c3f04f8c5faaa35106b3ab66060ce9868590adb33f3be1900c12ea196",
+			"block_height": 143895185,
+			"aliases": {}
+		},
+		"FlowEVMBridgeCustomAssociations": {
+			"source": "mainnet://1e4aa0b87d10b141.FlowEVMBridgeCustomAssociations",
+			"hash": "14d1f4ddd347f45d331e543830b94701e1aa1513c56d55c0019c7fac46d8a572",
+			"block_height": 143895185,
+			"aliases": {}
+		},
+		"FlowEVMBridgeHandlerInterfaces": {
+			"source": "mainnet://1e4aa0b87d10b141.FlowEVMBridgeHandlerInterfaces",
+			"hash": "e32154f2a556e53328a0fce75f1e98b57eefd2a8cb626e803b7d39d452691444",
+			"block_height": 143490006,
+			"aliases": {}
+		},
+		"FlowEVMBridgeNFTEscrow": {
+			"source": "mainnet://1e4aa0b87d10b141.FlowEVMBridgeNFTEscrow",
+			"hash": "30257592838edfd4b72700f43bf0326f6903e879f82ac5ca549561d9863c6fe6",
+			"block_height": 143895185,
+			"aliases": {}
+		},
+		"FlowEVMBridgeResolver": {
+			"source": "mainnet://1e4aa0b87d10b141.FlowEVMBridgeResolver",
+			"hash": "c1ac18e92828616771df5ff5d6de87866f2742ca4ce196601c11e977e4f63bb3",
+			"block_height": 143895185,
+			"aliases": {}
+		},
+		"FlowEVMBridgeTemplates": {
+			"source": "mainnet://1e4aa0b87d10b141.FlowEVMBridgeTemplates",
+			"hash": "78b8115eb0ef2be4583acbe655f0c5128c39712084ec23ce47820ea154141898",
+			"block_height": 143895185,
+			"aliases": {}
+		},
+		"FlowEVMBridgeTokenEscrow": {
+			"source": "mainnet://1e4aa0b87d10b141.FlowEVMBridgeTokenEscrow",
+			"hash": "49df9c8e5d0dd45abd5bf94376d3b9045299b3c2a5ba6caf48092c916362358d",
+			"block_height": 143895185,
+			"aliases": {}
+		},
+		"FlowEVMBridgeUtils": {
+			"source": "mainnet://1e4aa0b87d10b141.FlowEVMBridgeUtils",
+			"hash": "634ed6dde03eb8f027368aa7861889ce1f5099160903493a7a39a86c9afea14b",
+			"block_height": 143895185,
+			"aliases": {}
+		},
 		"FlowFees": {
 			"source": "mainnet://f919ee77447b7497.FlowFees",
 			"hash": "341cc0f3cc847d6b787c390133f6a5e6c867c111784f09c5c0083c47f2f1df64",
-			"block_height": 139085361,
+			"block_height": 143487068,
 			"aliases": {
 				"emulator": "e5a8b7f23e8b548f",
 				"mainnet": "f919ee77447b7497",
@@ -174,7 +274,7 @@
 		"FlowStorageFees": {
 			"source": "mainnet://e467b9dd11fa00df.FlowStorageFees",
 			"hash": "a92c26fb2ea59725441fa703aa4cd811e0fc56ac73d649a8e12c1e72b67a8473",
-			"block_height": 139085361,
+			"block_height": 143487068,
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "e467b9dd11fa00df",
@@ -185,7 +285,7 @@
 		"FlowToken": {
 			"source": "mainnet://1654653399040a61.FlowToken",
 			"hash": "f82389e2412624ffa439836b00b42e6605b0c00802a4e485bc95b8930a7eac38",
-			"block_height": 139085361,
+			"block_height": 143487068,
 			"aliases": {
 				"emulator": "0ae53cb6e3f42a79",
 				"mainnet": "1654653399040a61",
@@ -196,7 +296,7 @@
 		"FlowTransactionScheduler": {
 			"source": "mainnet://e467b9dd11fa00df.FlowTransactionScheduler",
 			"hash": "23157cf7d70534e45b0ab729133232d0ffb3cdae52661df1744747cb1f8c0495",
-			"block_height": 139085361,
+			"block_height": 143487068,
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "e467b9dd11fa00df",
@@ -207,7 +307,7 @@
 		"FlowTransactionSchedulerUtils": {
 			"source": "mainnet://e467b9dd11fa00df.FlowTransactionSchedulerUtils",
 			"hash": "71a1febab6b9ba76abec36dab1e61b1c377e44fbe627e5fac649deb71b727877",
-			"block_height": 141019535,
+			"block_height": 143487068,
 			"aliases": {
 				"mainnet": "e467b9dd11fa00df",
 				"mainnet-fork": "e467b9dd11fa00df"
@@ -216,7 +316,7 @@
 		"FungibleToken": {
 			"source": "mainnet://f233dcee88fe0abe.FungibleToken",
 			"hash": "4b74edfe7d7ddfa70b703c14aa731a0b2e7ce016ce54d998bfd861ada4d240f6",
-			"block_height": 139085361,
+			"block_height": 143487068,
 			"aliases": {
 				"emulator": "ee82856bf20e2aa6",
 				"mainnet": "f233dcee88fe0abe",
@@ -227,7 +327,7 @@
 		"FungibleTokenMetadataViews": {
 			"source": "mainnet://f233dcee88fe0abe.FungibleTokenMetadataViews",
 			"hash": "70477f80fd7678466c224507e9689f68f72a9e697128d5ea54d19961ec856b3c",
-			"block_height": 139085361,
+			"block_height": 143487068,
 			"aliases": {
 				"emulator": "ee82856bf20e2aa6",
 				"mainnet": "f233dcee88fe0abe",
@@ -235,10 +335,58 @@
 				"testnet": "9a0766d93b6608b7"
 			}
 		},
+		"IBridgePermissions": {
+			"source": "mainnet://1e4aa0b87d10b141.IBridgePermissions",
+			"hash": "431a51a6cca87773596f79832520b19499fe614297eaef347e49383f2ae809af",
+			"block_height": 143895185,
+			"aliases": {}
+		},
+		"ICrossVM": {
+			"source": "mainnet://1e4aa0b87d10b141.ICrossVM",
+			"hash": "b95c36eef516da7cd4d2f507cd48288cc16b1d6605ff03b6fcd18161ff2d82e7",
+			"block_height": 143895185,
+			"aliases": {}
+		},
+		"ICrossVMAsset": {
+			"source": "mainnet://1e4aa0b87d10b141.ICrossVMAsset",
+			"hash": "d9c7b2bd9fdcc454180c33b3509a5a060a7fe4bd49bce38818f22fd08acb8ba0",
+			"block_height": 143895185,
+			"aliases": {}
+		},
+		"IEVMBridgeNFTMinter": {
+			"source": "mainnet://1e4aa0b87d10b141.IEVMBridgeNFTMinter",
+			"hash": "e2ad15c495ad7fbf4ab744bccaf8c4334dfb843b50f09e9681ce9a5067dbf049",
+			"block_height": 143895185,
+			"aliases": {}
+		},
+		"IEVMBridgeTokenMinter": {
+			"source": "mainnet://1e4aa0b87d10b141.IEVMBridgeTokenMinter",
+			"hash": "0ef39c6cb476f0eea2c835900b6a5a83c1ed5f4dbaaeb29cb68ad52c355a40e6",
+			"block_height": 143895185,
+			"aliases": {}
+		},
+		"IFlowEVMNFTBridge": {
+			"source": "mainnet://1e4aa0b87d10b141.IFlowEVMNFTBridge",
+			"hash": "2d495e896510a10bbc7307739aca9341633cac4c7fe7dad32488a81f90a39dd9",
+			"block_height": 143895185,
+			"aliases": {}
+		},
+		"IFlowEVMTokenBridge": {
+			"source": "mainnet://1e4aa0b87d10b141.IFlowEVMTokenBridge",
+			"hash": "87f7d752da8446e73acd3bf4aa17fe5c279d9641b7976c56561af01bc5240ea4",
+			"block_height": 143895185,
+			"aliases": {}
+		},
+		"IncrementFiSwapConnectors": {
+			"source": "mainnet://e844c7cf7430a77c.IncrementFiSwapConnectors",
+			"hash": "adcc179a912afac1529b311ddb6124fddf25bb8fa90b207d4cc6bd797f1c1ed6",
+			"block_height": 143897851,
+			"aliases": {}
+		},
 		"MetadataViews": {
 			"source": "mainnet://1d7e57aa55817448.MetadataViews",
 			"hash": "b290b7906d901882b4b62e596225fb2f10defb5eaaab4a09368f3aee0e9c18b1",
-			"block_height": 139085361,
+			"block_height": 143487068,
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "1d7e57aa55817448",
@@ -249,7 +397,7 @@
 		"NonFungibleToken": {
 			"source": "mainnet://1d7e57aa55817448.NonFungibleToken",
 			"hash": "a258de1abddcdb50afc929e74aca87161d0083588f6abf2b369672e64cf4a403",
-			"block_height": 139085361,
+			"block_height": 143487068,
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "1d7e57aa55817448",
@@ -257,10 +405,100 @@
 				"testnet": "631e88ae7f1d7c20"
 			}
 		},
+		"Serialize": {
+			"source": "mainnet://1e4aa0b87d10b141.Serialize",
+			"hash": "064bb0d7b6c24ee1ed370cbbe9e0cda2a4e0955247de5e3e81f2f3a8a8cabfb7",
+			"block_height": 143895185,
+			"aliases": {
+				"mainnet": "1e4aa0b87d10b141"
+			}
+		},
+		"SerializeMetadata": {
+			"source": "mainnet://1e4aa0b87d10b141.SerializeMetadata",
+			"hash": "e9f84ea07e29cae05ee0d9264596eb281c291fc1090a10ce3de1a042b4d671da",
+			"block_height": 143895185,
+			"aliases": {
+				"mainnet": "1e4aa0b87d10b141"
+			}
+		},
+		"StableSwapFactory": {
+			"source": "mainnet://b063c16cac85dbd1.StableSwapFactory",
+			"hash": "a63b57a5cc91085016abc34c1b49622b385a8f976ac2ba0e646f7a3f780d344e",
+			"block_height": 143586532,
+			"aliases": {
+				"mainnet": "b063c16cac85dbd1",
+				"mainnet-fork": "b063c16cac85dbd1",
+				"testnet": "6ca93d49c45a249f"
+			}
+		},
+		"SwapConfig": {
+			"source": "mainnet://b78ef7afa52ff906.SwapConfig",
+			"hash": "111f3caa0ab506bed100225a1481f77687f6ac8493d97e49f149fa26a174ef99",
+			"block_height": 143586532,
+			"aliases": {
+				"mainnet": "b78ef7afa52ff906",
+				"mainnet-fork": "b78ef7afa52ff906",
+				"testnet": "8d5b9dd833e176da"
+			}
+		},
+		"SwapConnectors": {
+			"source": "mainnet://e1a479f0cb911df9.SwapConnectors",
+			"hash": "47d80d2d64adb28fe7a32bdbf630e3957edb76fc882603dd3ae5c7283d65cd42",
+			"block_height": 143894697,
+			"aliases": {
+				"mainnet": "e1a479f0cb911df9"
+			}
+		},
+		"SwapError": {
+			"source": "mainnet://b78ef7afa52ff906.SwapError",
+			"hash": "7d13a652a1308af387513e35c08b4f9a7389a927bddf08431687a846e4c67f21",
+			"block_height": 143586532,
+			"aliases": {
+				"mainnet": "b78ef7afa52ff906",
+				"mainnet-fork": "b78ef7afa52ff906",
+				"testnet": "8d5b9dd833e176da"
+			}
+		},
+		"SwapFactory": {
+			"source": "mainnet://b063c16cac85dbd1.SwapFactory",
+			"hash": "deea03edbb49877c8c72276e1911cf87bdba4052ae9c3ac54c0d4ac62f3ef511",
+			"block_height": 143586532,
+			"aliases": {
+				"mainnet": "b063c16cac85dbd1",
+				"mainnet-fork": "b063c16cac85dbd1",
+				"testnet": "6ca93d49c45a249f"
+			}
+		},
+		"SwapInterfaces": {
+			"source": "mainnet://b78ef7afa52ff906.SwapInterfaces",
+			"hash": "e559dff4d914fa12fff7ba482f30d3c575dc3d31587833fd628763d1a4ee96b2",
+			"block_height": 143888406,
+			"aliases": {
+				"mainnet": "b78ef7afa52ff906"
+			}
+		},
+		"SwapRouter": {
+			"source": "mainnet://a6850776a94e6551.SwapRouter",
+			"hash": "c0365c01978ca32af94602bfddd0796cfe6375e60a05b927b5de539e608baec5",
+			"block_height": 143586532,
+			"aliases": {
+				"mainnet": "a6850776a94e6551",
+				"mainnet-fork": "a6850776a94e6551",
+				"testnet": "2f8af5ed05bbde0d"
+			}
+		},
+		"USDCFlow": {
+			"source": "mainnet://f1ab99c82dee3526.USDCFlow",
+			"hash": "da7c21064dc73c06499f0b652caea447233465b49787605ce0f679beca48dee7",
+			"block_height": 143490006,
+			"aliases": {
+				"mainnet": "f1ab99c82dee3526"
+			}
+		},
 		"ViewResolver": {
 			"source": "mainnet://1d7e57aa55817448.ViewResolver",
 			"hash": "374a1994046bac9f6228b4843cb32393ef40554df9bd9907a702d098a2987bde",
-			"block_height": 139085361,
+			"block_height": 143487068,
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "1d7e57aa55817448",
@@ -295,14 +533,6 @@
 				"resourceID": "projects/dl-flow-devex-production/locations/us-central1/keyRings/tidal-keyring/cryptoKeys/tidal_admin_pk/cryptoKeyVersions/1"
 			}
 		},
-		"mainnet-fyv-deployer": {
-			"address": "b1d63873c3cc9f79",
-			"key": {
-				"type": "google-kms",
-				"hashAlgorithm": "SHA2_256",
-				"resourceID": "projects/dl-flow-devex-production/locations/us-central1/keyRings/tidal-keyring/cryptoKeys/tidal_admin_pk/cryptoKeyVersions/1"
-			}
-		},
 		"mainnet-fork-deployer": {
 			"address": "6b00ff876c299c61",
 			"key": {
@@ -315,6 +545,14 @@
 			"key": {
 				"type": "file",
 				"location": "emulator-account.pkey"
+			}
+		},
+		"mainnet-fyv-deployer": {
+			"address": "b1d63873c3cc9f79",
+			"key": {
+				"type": "google-kms",
+				"hashAlgorithm": "SHA2_256",
+				"resourceID": "projects/dl-flow-devex-production/locations/us-central1/keyRings/tidal-keyring/cryptoKeys/tidal_admin_pk/cryptoKeyVersions/1"
 			}
 		},
 		"testnet-deployer": {
@@ -350,6 +588,10 @@
 					]
 				},
 				"FlowALPv0"
+			],
+			"mainnet-fork-deployer": [
+				"USDCFlow",
+				"FlowEVMBridgeHandlerInterfaces"
 			]
 		},
 		"mainnet": {
@@ -370,7 +612,6 @@
 				"MockDexSwapper",
 				"MockOracle"
 			]
-
 		},
 		"mainnet-fork": {
 			"mainnet-fork-deployer": [
@@ -390,7 +631,6 @@
 				"MockDexSwapper",
 				"MockOracle"
 			]
-
 		},
 		"testnet": {
 			"testnet-deployer": [


### PR DESCRIPTION
## Description

Testable with: (cd FlowActions && git checkout holyfuchs/incrementfi-price-oracle)

Add test for using external DefiActions.PriceOracle provided by band and increment.fi
They will be used in the oracleAggregator.