### PR TITLE
fix: prevent closePosition panic when withdrawals map is empty

### DIFF
--- a/cadence/contracts/FlowALPv0.cdc
+++ b/cadence/contracts/FlowALPv0.cdc
@@ -3332,8 +3332,10 @@ access(all) contract FlowALPv0 {
 
             // Step 7: Build withdrawals map for event (vaults are in same order as collateralTypes)
             let withdrawalsByType: {Type: UFix64} = {}
-            for i in InclusiveRange(0, vaults.length-1) {
+            var i = 0
+            while i < vaults.length {
                 withdrawalsByType[vaults[i].getType()] = vaults[i].balance
+                i = i + 1
             }
 
             // Step 8: Emit position closed event

--- a/cadence/tests/close_position_empty_position_test.cdc
+++ b/cadence/tests/close_position_empty_position_test.cdc
@@ -1,0 +1,78 @@
+import Test
+import BlockchainHelpers
+
+import "MOET"
+import "FlowALPv0"
+import "test_helpers.cdc"
+
+access(all) var snapshot: UInt64 = 0
+
+access(all)
+fun safeReset() {
+    let cur = getCurrentBlockHeight()
+    if cur > snapshot {
+        Test.reset(to: snapshot)
+    }
+}
+
+access(all)
+fun setup() {
+    deployContracts()
+    createAndStorePool(signer: PROTOCOL_ACCOUNT, defaultTokenIdentifier: MOET_TOKEN_IDENTIFIER, beFailed: false)
+    snapshot = getCurrentBlockHeight()
+}
+
+/// Regression test for closePosition empty-withdrawals map handling.
+///
+/// Scenario:
+/// 1) Open a position with collateral and no debt.
+/// 2) Withdraw all collateral so the position has no balances.
+/// 3) Close the position.
+///
+/// Expected: close succeeds (must not panic on empty vault array).
+access(all)
+fun test_closePosition_afterFullWithdrawal_noDebtNoCollateral() {
+    safeReset()
+
+    setMockOraclePrice(signer: PROTOCOL_ACCOUNT, forTokenIdentifier: FLOW_TOKEN_IDENTIFIER, price: 1.0)
+    addSupportedTokenZeroRateCurve(
+        signer: PROTOCOL_ACCOUNT,
+        tokenTypeIdentifier: FLOW_TOKEN_IDENTIFIER,
+        collateralFactor: 0.8,
+        borrowFactor: 1.0,
+        depositRate: 1_000_000.0,
+        depositCapacityCap: 1_000_000.0
+    )
+
+    let user = Test.createAccount()
+    setupMoetVault(user, beFailed: false)
+    mintFlow(to: user, amount: 1_000.0)
+    grantBetaPoolParticipantAccess(PROTOCOL_ACCOUNT, user)
+
+    let openRes = _executeTransaction(
+        "../transactions/flow-alp/position/create_position.cdc",
+        [100.0, FLOW_VAULT_STORAGE_PATH, false],
+        user
+    )
+    Test.expect(openRes, Test.beSucceeded())
+
+    let withdrawRes = _executeTransaction(
+        "./transactions/position-manager/withdraw_from_position.cdc",
+        [UInt64(0), FLOW_TOKEN_IDENTIFIER, 100.0, false],
+        user
+    )
+    Test.expect(withdrawRes, Test.beSucceeded())
+
+    let closeRes = _executeTransaction(
+        "../transactions/flow-alp/position/repay_and_close_position.cdc",
+        [UInt64(0)],
+        user
+    )
+    Test.expect(closeRes, Test.beSucceeded())
+
+    let flowBalanceAfter = getBalance(address: user.address, vaultPublicPath: /public/flowTokenReceiver)!
+    Test.assert(
+        flowBalanceAfter >= 1_000.0 - DEFAULT_UFIX_VARIANCE,
+        message: "Expected all FLOW to be returned after full withdrawal and close"
+    )
+}


### PR DESCRIPTION
## Summary
This PR fixes an edge-case panic in `closePosition` when the position has no debt and no remaining collateral at close time.

## Real panic scenario (before this fix)
1. User opens a position and deposits `100.0 FLOW`.
2. User never borrows.
3. User withdraws the full `100.0 FLOW`.
4. User calls `repay_and_close_position.cdc` to close.

At this point in `closePosition`:
- `debtsByType = {}` (no debt to repay),
- `collateralTypes = []`,
- `_withdrawAllCollateral(...)` returns `vaults = []`.

The old code then built `withdrawalsByType` with:
- `for i in InclusiveRange(0, vaults.length - 1)`

With `vaults.length == 0`, this range evaluates to `InclusiveRange(0, -1)` (which iterates `0, -1`).
The first iteration tries `vaults[0]` on an empty array, causing an out-of-bounds runtime panic and reverting close.

## Root cause
Using an index-based loop that assumes a non-empty array when building `withdrawalsByType`.

## Fix
In `FlowALPv0.cdc` close flow, replaced the inclusive-range index loop with a bounds-safe loop:
- `var i = 0`
- `while i < vaults.length { ...; i = i + 1 }`

This preserves behavior for non-empty arrays and safely no-ops for empty arrays.

## Why this is safe
- No change to close business logic.
- No change to debt repayment semantics.
- No API changes.
- Change is localized to event-map construction (`withdrawalsByType`) and only affects iteration safety.

## Tests
Added regression test:
- `cadence/tests/close_position_empty_position_test.cdc`

The test executes the real scenario above and asserts close succeeds without panic and funds are returned as expected.

Also re-ran existing close-related tests to ensure no regressions:
- `close_position_dust_return_test.cdc`
- `close_position_precision_test.cdc`
- `close_position_queued_overpayment_test.cdc`
- `close_position_rounding_overpayment_test.cdc`

## Risk / Compatibility
- Low risk.
- Backward compatible.
- Prevents a production-blocking close failure for valid no-debt / fully-withdrawn positions.
