### PR TITLE
docs: Quantstamp second round audit analysis with Claude recommendations

### DIFF
--- a/docs/quantstamp-review-2-analysis.md
+++ b/docs/quantstamp-review-2-analysis.md
@@ -741,9 +741,12 @@ Make `fixReschedule` non-panicking on missing UUID (use optional unwrap + early 
 
 **Recommendation:** Fix this. The force-unwrap is clearly wrong – missing UUID should be a soft warning, not a panic. Change `borrowRebalancer(uuid)!` to `borrowRebalancer(uuid) ?? return` (guard pattern). Also see FLO-4: part of the fix for FLO-4 is tracking active rebalancer UUIDs – that same registry should be the authoritative source for the Supervisor set, ensuring they stay in sync.
 
-**Action:** `[ ] No Action  [ ] Code Changes  [ ] Documentation`
-**DRI:**
+**Action:** `[ ] No Action  [x] Code Changes  [ ] Documentation`
+**DRI:** holyfuchs
 **Notes:**
+- `fixReschedule(uuid:)` now returns `Bool` (true = found, false = stale) instead of force-unwrapping.
+- The Supervisor's `executeTransaction` loop checks the return value and calls `removePaidRebalancer(uuid:)` to self-clean stale entries automatically.
+- Regression test added: `test_supervisor_stale_uuid_does_not_panic` in `paid_auto_balance_test.cdc` verifies no panic, that `Executed` is emitted, that `RemovedPaidRebalancer` fires for the stale UUID, and that the UUID is not re-removed on a subsequent tick.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds `docs/quantstamp-review-2-analysis.md` covering all 31 findings from the Quantstamp second round review (audit commit `abea0e2`). For each finding:
- Current code status checked against `FlowALPv0.cdc` (renamed from `FlowALPv1.cdc`)
- Claude recommendation on priority and suggested fix
- Blank DRI / Action / Notes fields for the team to fill in during the review call

## Notable code-status findings

| Status | Findings |
|--------|----------|
| Appears addressed | FLO-13 (fee collection decoupled from liquidation path) |
| Still present | FLO-1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 14, 15, 16, 17, 23, 26, 27, 28 |

Key callouts:
- **FLO-9**: `regenerateDepositCapacity()` still permanently inflates `depositCapacityCap` — rate limiting is broken over time
- **FLO-16**: One-line floor-at-zero fix that unblocks credit→debit withdrawals
- **FLO-17 + FLO-28**: Must be fixed together (fixing one creates the deadlock described by the other)

## Test plan

- [ ] Review the analysis doc before the Quantstamp call
- [ ] Fill in Action / DRI / Notes fields during the call
- [ ] File individual issues for findings marked as fix-before-launch priority

🤖 Generated with [Claude Code](https://claude.com/claude-code)