### PR TITLE
docs: FlowALP v1 Supported Features reference

### DIFF
--- a/docs/v1_supported_features.md
+++ b/docs/v1_supported_features.md
@@ -11,7 +11,7 @@
 | FLOW  | Native Flow token | 0.80 | 0.90 |
 | WETH  | EVM-bridged | 0.75 | 0.85 |
 | WBTC  | EVM-bridged | 0.70 | 0.80 |
-| MOET  | Protocol token | ⚠️ TBD | ⚠️ TBD |
+| MOET  | Protocol token | ⚠️ ??? | ⚠️ ??? |
 
 > ⚠️ **USDF** appears in fork test configurations alongside FLOW/WETH/WBTC — confirm whether it is in v1 scope.
 
@@ -36,7 +36,7 @@
 
 | Parameter | Value | Notes |
 |-----------|-------|-------|
-| Minimum position value | ⚠️ TBD | Set via governance (`setMinimumTokenBalancePerPosition`) |
+| Minimum position value | ⚠️ ??? | Set via governance (`setMinimumTokenBalancePerPosition`) |
 | Maximum deposit per token | 1,000,000 (default) | Governance-configurable cap per token |
 | Deposit limit fraction | 5% of capacity per deposit | Default; configurable per token |
 
@@ -78,8 +78,8 @@ The rebalancing interval is configurable per position via `RecurringConfigImplv1
 
 | Parameter | Value | Notes |
 |-----------|-------|-------|
-| Insurance rate | ⚠️ TBD | Governance-configurable per token |
-| Stability fee rate | ⚠️ TBD | Governance-configurable per token |
+| Insurance rate | ⚠️ ??? | Governance-configurable per token |
+| Stability fee rate | ⚠️ ??? | Governance-configurable per token |
 | Combined constraint | `insuranceRate + stabilityFeeRate < 100%` | Enforced by contract |
 
 ---


### PR DESCRIPTION
## Summary

- Adds `docs/v1_supported_features.md` — a reference doc for the first version of FlowALP
- Covers supported collateral tokens (FLOW, WETH, WBTC, MOET), MOET-only debt output, health factors, rebalancing (10 min default), liquidation thresholds, and the fee model
- Open items are flagged inline (⚠️) for team confirmation before this is published

## Open Items to Resolve

| # | Item |
|---|------|
| 1 | MOET collateral factor & borrow factor for v1 |
| 2 | Confirm USDF inclusion in v1 scope |
| 3 | Minimum position value floor |
| 4 | Confirm 1,000,000 deposit cap is the intended v1 limit |
| 5 | Insurance rate and stability fee values per collateral |

## Test plan
- [ ] Review doc values against final governance deployment config
- [ ] Resolve all ⚠️ open items and remove draft status

🤖 Generated with [Claude Code](https://claude.com/claude-code)