### PR TITLE
docs: align utilization semantics with kink curve behavior

### DIFF
--- a/cadence/contracts/FlowALPInterestRates.cdc
+++ b/cadence/contracts/FlowALPInterestRates.cdc
@@ -48,8 +48,10 @@ access(all) contract FlowALPInterestRates {
     /// This creates a "kinked" curve that incentivizes maintaining utilization near the
     /// optimal point while heavily penalizing over-utilization to protect protocol liquidity.
     ///
-    /// Formula:
-    /// - utilization = min(debitBalance / creditBalance, 1.0)
+    /// Utilization handling:
+    /// - if debitBalance == 0, treat utilization as 0% and return baseRate
+    /// - else if creditBalance == 0, saturate utilization at 100%
+    /// - else utilization = min(debitBalance / creditBalance, 1.0)
     /// - Before kink (utilization <= optimalUtilization):
     ///   rate = baseRate + (slope1 × utilization / optimalUtilization)
     /// - After kink (utilization > optimalUtilization):

--- a/docs/interest_rate_and_protocol_fees.md
+++ b/docs/interest_rate_and_protocol_fees.md
@@ -36,8 +36,13 @@ Both fees are deducted from the interest income that would otherwise go to lende
 
 For each token, the protocol stores one interest curve. The debit rate (borrow APY) is computed from that curve and the current pool utilization:
 
-```
-utilization = min(totalDebitBalance / totalCreditBalance, 1.0)
+```text
+if totalDebitBalance == 0:
+    utilization = 0
+else if totalCreditBalance == 0:
+    utilization = 100%
+else:
+    utilization = min(totalDebitBalance / totalCreditBalance, 1.0)
 
 debitRate = interestCurve.interestRate(
     creditBalance: totalCreditBalance,


### PR DESCRIPTION
## Summary
- fix the interest-rate docs to use the current utilization semantics on main
- clarify that totalCreditBalance means total supplied ( i.e total creditor claims), not remaining idle liquidity
- document the debit==0 and credit==0 edge-case handling reflected by the current KinkCurve comments

## Validation
- not run (docs/comment-only changes)
