### PR TITLE
add script that is used by FCM observer

### DIFF
--- a/cadence/scripts/flow-alp/get_moet_total_supply.cdc
+++ b/cadence/scripts/flow-alp/get_moet_total_supply.cdc
@@ -1,0 +1,5 @@
+import "MOET"
+
+access(all) fun main(): UFix64 {
+    return MOET.totalSupply
+}


### PR DESCRIPTION
Tested locally:

```
➜  FlowALP git:(illia-malachyn/add-get-moet-total-supply-script) flow scripts execute cadence/scripts/flow-alp/get_moet_total_supply.cdc --network mainnet

❗   Version warning: a new version of Flow CLI is available (v2.15.1).
   Read the installation guide for upgrade instructions: https://developers.flow.com/tools/flow-cli/install 


Result: 87772.09735101
```