### PR TITLE
Add Pool.getPositionCount() and get_position_count script

### DIFF
--- a/cadence/contracts/FlowALPv0.cdc
+++ b/cadence/contracts/FlowALPv0.cdc
@@ -1656,7 +1656,13 @@ access(all) contract FlowALPv0 {
         /// Returns whether a given token Type is supported or not
         access(all) view fun isTokenSupported(tokenType: Type): Bool {
             return self.globalLedger[tokenType] != nil
-        } 
+        }
+
+        /// Returns the total number of currently active positions in the Pool.
+        /// A position is counted from the moment it is created until it is closed.
+        access(all) view fun getPositionCount(): Int {
+            return self.positions.length
+        }
 
         /// Returns the current balance of the stability fund for a given token type.
         /// Returns nil if the token type is not supported.

--- a/cadence/scripts/flow-alp/get_position_count.cdc
+++ b/cadence/scripts/flow-alp/get_position_count.cdc
@@ -1,0 +1,11 @@
+import "FlowALPv0"
+
+/// Returns the total number of currently active positions in the FlowALPv0 Pool.
+///
+access(all)
+fun main(): Int {
+    let protocolAddress = Type<@FlowALPv0.Pool>().address!
+    return getAccount(protocolAddress).capabilities.borrow<&FlowALPv0.Pool>(FlowALPv0.PoolPublicPath)
+        ?.getPositionCount()
+        ?? panic("Could not find a configured FlowALPv0 Pool in account \(protocolAddress) at path \(FlowALPv0.PoolPublicPath)")
+}

--- a/cadence/tests/get_position_count_test.cdc
+++ b/cadence/tests/get_position_count_test.cdc
@@ -1,0 +1,73 @@
+import Test
+import BlockchainHelpers
+
+import "MOET"
+import "FlowALPv0"
+import "test_helpers.cdc"
+
+// -----------------------------------------------------------------------------
+// get_position_count script test
+//
+// Verifies that the get_position_count.cdc script correctly returns the total
+// number of active positions in the Pool via the Pool.getPositionCount() getter.
+// -----------------------------------------------------------------------------
+
+access(all)
+fun setup() {
+    deployContracts()
+
+    setMockOraclePrice(signer: PROTOCOL_ACCOUNT, forTokenIdentifier: FLOW_TOKEN_IDENTIFIER, price: 1.0)
+    createAndStorePool(signer: PROTOCOL_ACCOUNT, defaultTokenIdentifier: MOET_TOKEN_IDENTIFIER, beFailed: false)
+    addSupportedTokenZeroRateCurve(
+        signer: PROTOCOL_ACCOUNT,
+        tokenTypeIdentifier: FLOW_TOKEN_IDENTIFIER,
+        collateralFactor: 0.8,
+        borrowFactor: 1.0,
+        depositRate: 1_000_000.0,
+        depositCapacityCap: 1_000_000.0
+    )
+}
+
+// getPositionCount returns 0 when no positions have been opened
+access(all)
+fun test_position_count_is_zero_initially() {
+    let res = _executeScript("../scripts/flow-alp/get_position_count.cdc", [])
+    Test.expect(res, Test.beSucceeded())
+    let count = res.returnValue as! Int
+    Test.assertEqual(0, count)
+}
+
+// getPositionCount increments as positions are opened
+access(all)
+fun test_position_count_reflects_open_positions() {
+    let user1 = Test.createAccount()
+    let user2 = Test.createAccount()
+    setupMoetVault(user1, beFailed: false)
+    setupMoetVault(user2, beFailed: false)
+    mintFlow(to: user1, amount: 1_000.0)
+    mintFlow(to: user2, amount: 1_000.0)
+    grantBetaPoolParticipantAccess(PROTOCOL_ACCOUNT, user1)
+    grantBetaPoolParticipantAccess(PROTOCOL_ACCOUNT, user2)
+
+    // Open first position
+    let open1 = executeTransaction(
+        "../transactions/flow-alp/position/create_position.cdc",
+        [100.0, FLOW_VAULT_STORAGE_PATH, true],
+        user1
+    )
+    Test.expect(open1, Test.beSucceeded())
+
+    let countAfterOne = (_executeScript("../scripts/flow-alp/get_position_count.cdc", []).returnValue as! Int?)!
+    Test.assertEqual(1, countAfterOne)
+
+    // Open second position
+    let open2 = executeTransaction(
+        "../transactions/flow-alp/position/create_position.cdc",
+        [100.0, FLOW_VAULT_STORAGE_PATH, true],
+        user2
+    )
+    Test.expect(open2, Test.beSucceeded())
+
+    let countAfterTwo = (_executeScript("../scripts/flow-alp/get_position_count.cdc", []).returnValue as! Int?)!
+    Test.assertEqual(2, countAfterTwo)
+}


### PR DESCRIPTION
## Summary

- Adds `getPositionCount() : Int` as a public `view` function on the `Pool` resource in `FlowALPv0.cdc`, returning `self.positions.length`
- Adds `cadence/scripts/flow-alp/get_position_count.cdc` — a Cadence script that resolves the Pool from the protocol account and returns the count
- Adds `cadence/tests/get_position_count_test.cdc` covering: zero count on a fresh pool, and correct increment as positions are opened

## Context

This is needed for the **FCM Observer** to be able to query the total number of active positions in the Pool without requiring any off-chain event indexing or privileged access.

## Test plan

- [x] `test_position_count_is_zero_initially` — asserts count is 0 before any positions are opened
- [x] `test_position_count_reflects_open_positions` — opens 2 positions across 2 users, asserts count increments correctly to 1 then 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)