### PR TITLE
Improve total balance documentation

### DIFF
--- a/cadence/contracts/FlowALPModels.cdc
+++ b/cadence/contracts/FlowALPModels.cdc
@@ -1514,6 +1514,14 @@ access(all) contract FlowALPModels {
             }
         }
 
+        /// NOTE: For all {decrease,increase}{Credit,Debit}Balance functions below:
+        /// If a deposit flips a position direction from debit to credit, the debt removal and credit addition must be applied as separate operations.
+        /// (The same requirement holds in reverse for a withdrawal flipping a credit balance to a debit balance.)
+        ///
+        /// For example, if a position has a debit balance of 100FLOW, then deposits 150FLOW, we MUST do:
+        ///  - decreaseDebitBalance(by: 100)
+        ///  - increaseCreditBalance(by: 50)
+
         /// Increases total non-interest-adjusted credit balance and recalculates interest rates.
         /// This function MUST be called each time a creditor's balance increases (deposit).
         /// The amount parameter must be equal to the amount of the deposit.


### PR DESCRIPTION
This PR aims to make it clear that the total credit/debit balance fields differ from other balance tracking. In positions, we track a scaled balance, which can be converted to a true balance using a frequently-updated interest index.

The total balance fields are neither a scaled balance nor a true value. They represent actual in- and out-flows of tokens, and do not account for interest accrual. We expect them to relate to the reserve balances, but not to interest-adjust position balances.