### PR TITLE
Add position health updated event

### DIFF
--- a/cadence/contracts/FlowALPv0.cdc
+++ b/cadence/contracts/FlowALPv0.cdc
@@ -144,6 +144,11 @@ access(all) contract FlowALPv0 {
         remainingCapacity: UFix64
     )
 
+    access(all) event PositionHealthUpdated(
+        pid: UInt64,
+        health: UFix128
+    )
+
     //// Emitted each time the insurance rate is updated for a specific token in a specific pool.
     //// The insurance rate is an annual percentage; for example a value of 0.001 indicates 0.1%.
     access(all) event InsuranceRateUpdated(
@@ -3958,6 +3963,7 @@ access(all) contract FlowALPv0 {
             }
 
             let positionHealth = self.positionHealth(pid: pid)
+            emit PositionHealthUpdated(pid: pid, health: positionHealth)
 
             if positionHealth < position.minHealth || positionHealth > position.maxHealth {
                 // This position is outside the configured health bounds, we queue it for an update


### PR DESCRIPTION
### Motivation 
The FCM observer currently fetches positions’ health by running scripts (`get_position_by_id.cdc`). This approach doesn’t scale well.

For example, with ~10,000 positions, we need to execute 10,000 script calls. Access nodes are rate-limited (typically ~1–5 requests/sec), so processing all positions takes a significant amount of time.

### Change
- Introduce an event-based approach for tracking position health.
- Instead of polling via scripts, we subscribe to events over a WebSocket (TCP) stream. This allows us to process a high volume of updates in real time, without being constrained by request rate limits.

### Result 
- Eliminates the need for per-position script calls
- Avoids access node rate limits
- Enables near real-time updates
- Scales much better with the number of positions