### PR TITLE
Optimize iteration over dictionary keys

### DIFF
--- a/cadence/contracts/FlowALPModels.cdc
+++ b/cadence/contracts/FlowALPModels.cdc
@@ -553,7 +553,7 @@ access(all) contract FlowALPModels {
             effectiveDebt: {Type: UFix128}
         ) {
             // Enforce single balance per token invariant: if a type appears in one map, it must not appear in the other.
-            for collateralType in effectiveCollateral.keys {
+            for collateralType in effectiveCollateral {
                 assert(effectiveDebt[collateralType] == nil, message: "cannot construct BalanceSheet: observed both credit and debit balance for \(collateralType.identifier)")
             }
 


### PR DESCRIPTION


## Description

Since [Cadence v1.10.0](https://github.com/onflow/cadence/releases/tag/v1.10.0) direct iteration over dictionaries is supported, which avoids temporarily constructing an array of all keys.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-ft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer