### PR TITLE
Round down position availableBalance to avoid exceeding capacity

### DIFF
--- a/cadence/contracts/FlowALPv0.cdc
+++ b/cadence/contracts/FlowALPv0.cdc
@@ -1829,7 +1829,8 @@ access(all) contract FlowALPv0 {
                 withdrawBal: withdrawBal,
                 targetHealth: view.minHealth
             )
-            return FlowALPMath.toUFix64Round(uintMax)
+            // Round down to avoid allowing withdrawal of more than is safe
+            return FlowALPMath.toUFix64RoundDown(uintMax)
         }
 
         /// Returns the health of the given position, which is the ratio of the position's effective collateral


### PR DESCRIPTION
## Description

By rounding the `availableBalance` of a position up, we will exceed the withdrawable capacity, which could be used by a caller.  This PR changes the behaviour to always round down instead.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/FlowALP/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 