### PR TITLE
Gate manualLiquidation by EParticipant entitlement

### DIFF
--- a/cadence/contracts/FlowALPv0.cdc
+++ b/cadence/contracts/FlowALPv0.cdc
@@ -1977,7 +1977,7 @@ access(all) contract FlowALPv0 {
         /// - C means collateral: Ce is effective collateral, Ct is true collateral, measured in $
         /// - D means debt: De is effective debt, Dt is true debt, measured in $
         /// - Fc, Fd are collateral and debt factors
-        access(all) fun manualLiquidation(
+        access(EParticipant) fun manualLiquidation(
             pid: UInt64,
             debtType: Type,
             seizeType: Type,

--- a/cadence/tests/liquidation_phase1_test.cdc
+++ b/cadence/tests/liquidation_phase1_test.cdc
@@ -75,6 +75,7 @@ fun testManualLiquidation_healthyPosition() {
     // Repay MOET to seize FLOW
     let repayAmount = 2.0
     let seizeAmount = 1.0
+    grantBetaPoolParticipantAccess(PROTOCOL_ACCOUNT, liquidator)
     let liqRes = _executeTransaction(
         "../transactions/flow-alp/pool-management/manual_liquidation.cdc",
         [pid, Type<@MOET.Vault>().identifier, FLOW_TOKEN_IDENTIFIER, seizeAmount, repayAmount],
@@ -126,6 +127,7 @@ fun testManualLiquidation_liquidationExceedsTargetHealth() {
     // TODO(jord): add helper to compute health boundaries given best acceptable price, then test boundaries
     let repayAmount = 500.0
     let seizeAmount = 500.0
+    grantBetaPoolParticipantAccess(PROTOCOL_ACCOUNT, liquidator)
     let liqRes = _executeTransaction(
         "../transactions/flow-alp/pool-management/manual_liquidation.cdc",
         [pid, Type<@MOET.Vault>().identifier, FLOW_TOKEN_IDENTIFIER, seizeAmount, repayAmount],
@@ -186,6 +188,7 @@ fun testManualLiquidation_repayExceedsDebt() {
     // Repay MOET to seize FLOW. Choose repay amount above debt balance
     let repayAmount = debtBalance + 0.001
     let seizeAmount = (repayAmount / newPrice) * 0.99
+    grantBetaPoolParticipantAccess(PROTOCOL_ACCOUNT, liquidator)
     let liqRes = _executeTransaction(
         "../transactions/flow-alp/pool-management/manual_liquidation.cdc",
         [pid, Type<@MOET.Vault>().identifier, FLOW_TOKEN_IDENTIFIER, seizeAmount, repayAmount],
@@ -244,6 +247,7 @@ fun testManualLiquidation_seizeExceedsCollateral() {
     // Repay MOET to seize FLOW. Choose seize amount above collateral balance
     let seizeAmount = collateralBalance + 0.001
     let repayAmount = seizeAmount * newPrice * 1.01
+    grantBetaPoolParticipantAccess(PROTOCOL_ACCOUNT, liquidator)
     let liqRes = _executeTransaction(
         "../transactions/flow-alp/pool-management/manual_liquidation.cdc",
         [pid, Type<@MOET.Vault>().identifier, FLOW_TOKEN_IDENTIFIER, seizeAmount, repayAmount],
@@ -303,6 +307,7 @@ fun testManualLiquidation_reduceHealth() {
     // Repay MOET to seize FLOW. Choose seize amount above collateral balance
     let seizeAmount = collateralBalancePreLiq - 0.01
     let repayAmount = seizeAmount * newPrice * 1.01
+    grantBetaPoolParticipantAccess(PROTOCOL_ACCOUNT, liquidator)
     let liqRes = _executeTransaction(
         "../transactions/flow-alp/pool-management/manual_liquidation.cdc",
         [pid, Type<@MOET.Vault>().identifier, FLOW_TOKEN_IDENTIFIER, seizeAmount, repayAmount],
@@ -366,6 +371,7 @@ fun testManualLiquidation_increaseHealthBelowTarget() {
     // Liquidator offers 150 FLOW < 200 FLOW (better price)
     let repayAmount = 100.0
     let seizeAmount = 150.0
+    grantBetaPoolParticipantAccess(PROTOCOL_ACCOUNT, liquidator)
     let liqRes = _executeTransaction(
         "../transactions/flow-alp/pool-management/manual_liquidation.cdc",
         [pid, Type<@MOET.Vault>().identifier, FLOW_TOKEN_IDENTIFIER, seizeAmount, repayAmount],
@@ -431,6 +437,7 @@ fun testManualLiquidation_liquidateToTarget() {
     // Liquidator offers 33.66 FLOW < 142.86 FLOW (better price)
     let repayAmount = 100.0
     let seizeAmount = 33.66
+    grantBetaPoolParticipantAccess(PROTOCOL_ACCOUNT, liquidator)
     let liqRes = _executeTransaction(
         "../transactions/flow-alp/pool-management/manual_liquidation.cdc",
         [pid, Type<@MOET.Vault>().identifier, FLOW_TOKEN_IDENTIFIER, seizeAmount, repayAmount],
@@ -488,6 +495,7 @@ fun testManualLiquidation_repaymentVaultCollateralType() {
     // Purport to repay MOET to seize FLOW, but we will actually pass in a FLOW vault for repayment
     let repayAmount = debtBalance + 0.001
     let seizeAmount = (repayAmount / newPrice) * 0.99
+    grantBetaPoolParticipantAccess(PROTOCOL_ACCOUNT, liquidator)
     let liqRes = _executeTransaction(
         "../tests/transactions/flow-alp/pool-management/manual_liquidation_chosen_vault.cdc",
         [pid, Type<@MOET.Vault>().identifier, FLOW_TOKEN_IDENTIFIER, FLOW_TOKEN_IDENTIFIER, seizeAmount, repayAmount],
@@ -544,6 +552,7 @@ fun testManualLiquidation_repaymentVaultTypeMismatch() {
     // Purport to repay MOET to seize FLOW, but we will actually pass in a MockYieldToken vault for repayment
     let repayAmount = debtBalance + 0.001
     let seizeAmount = (repayAmount / newPrice) * 0.99
+    grantBetaPoolParticipantAccess(PROTOCOL_ACCOUNT, liquidator)
     let liqRes = _executeTransaction(
         "../tests/transactions/flow-alp/pool-management/manual_liquidation_chosen_vault.cdc",
         [pid, Type<@MOET.Vault>().identifier, MOCK_YIELD_TOKEN_IDENTIFIER, FLOW_TOKEN_IDENTIFIER, seizeAmount, repayAmount],
@@ -599,6 +608,7 @@ fun testManualLiquidation_unsupportedDebtType() {
     // Pass in MockYieldToken as repayment, an unsupported debt type
     let repayAmount = debtBalance + 0.001
     let seizeAmount = (repayAmount / newPrice) * 0.99
+    grantBetaPoolParticipantAccess(PROTOCOL_ACCOUNT, liquidator)
     let liqRes = _executeTransaction(
         "../tests/transactions/flow-alp/pool-management/manual_liquidation_chosen_vault.cdc",
         [pid, MOCK_YIELD_TOKEN_IDENTIFIER, MOCK_YIELD_TOKEN_IDENTIFIER, FLOW_TOKEN_IDENTIFIER, seizeAmount, repayAmount],
@@ -654,6 +664,7 @@ fun testManualLiquidation_unsupportedCollateralType() {
     // Repay MOET to seize FLOW. Choose seize amount above collateral balance
     let seizeAmount = collateralBalancePreLiq - 0.01
     let repayAmount = seizeAmount * newPrice * 1.01
+    grantBetaPoolParticipantAccess(PROTOCOL_ACCOUNT, liquidator)
     let liqRes = _executeTransaction(
         "../transactions/flow-alp/pool-management/manual_liquidation.cdc",
         [pid, Type<@MOET.Vault>().identifier, MOCK_YIELD_TOKEN_IDENTIFIER, seizeAmount, repayAmount],
@@ -738,6 +749,7 @@ fun testManualLiquidation_supportedDebtTypeNotInPosition() {
     // user1 has no MockYieldToken debt balance 
     let seizeAmount = 0.01
     let repayAmount = 100.0
+    grantBetaPoolParticipantAccess(PROTOCOL_ACCOUNT, liquidator)
     let liqRes = _executeTransaction(
         "../transactions/flow-alp/pool-management/manual_liquidation.cdc",
         [pid1, MOCK_YIELD_TOKEN_IDENTIFIER, FLOW_TOKEN_IDENTIFIER, seizeAmount, repayAmount],
@@ -822,6 +834,7 @@ fun testManualLiquidation_supportedCollateralTypeNotInPosition() {
     // User1 only has MOET debt, not MockYieldToken debt
     let seizeAmount = 0.01
     let repayAmount = 100.0
+    grantBetaPoolParticipantAccess(PROTOCOL_ACCOUNT, liquidator)
     let liqRes = _executeTransaction(
         "../transactions/flow-alp/pool-management/manual_liquidation.cdc",
         [pid1, Type<@MOET.Vault>().identifier, MOCK_YIELD_TOKEN_IDENTIFIER, seizeAmount, repayAmount],
@@ -881,6 +894,7 @@ fun testManualLiquidation_dexOraclePriceDivergence_withinThreshold() {
     // Liquidator offers 72 FLOW < 73.53 FLOW (better price)
     let repayAmount = 50.0
     let seizeAmount = 72.0
+    grantBetaPoolParticipantAccess(PROTOCOL_ACCOUNT, liquidator)
     let liqRes = _executeTransaction(
         "../transactions/flow-alp/pool-management/manual_liquidation.cdc",
         [pid, Type<@MOET.Vault>().identifier, FLOW_TOKEN_IDENTIFIER, seizeAmount, repayAmount],
@@ -917,6 +931,7 @@ fun testManualLiquidation_dexOraclePriceDivergence_dexBelowOracle() {
     setupMoetVault(liquidator, beFailed: false)
     mintMoet(signer: Test.getAccount(0x0000000000000007), to: liquidator.address, amount: 1000.0, beFailed: false)
 
+    grantBetaPoolParticipantAccess(PROTOCOL_ACCOUNT, liquidator)
     let liqRes = _executeTransaction(
         "../transactions/flow-alp/pool-management/manual_liquidation.cdc",
         [pid, Type<@MOET.Vault>().identifier, FLOW_TOKEN_IDENTIFIER, 70.0, 50.0],
@@ -954,6 +969,7 @@ fun testManualLiquidation_dexOraclePriceDivergence_dexAboveOracle() {
     setupMoetVault(liquidator, beFailed: false)
     mintMoet(signer: Test.getAccount(0x0000000000000007), to: liquidator.address, amount: 1000.0, beFailed: false)
 
+    grantBetaPoolParticipantAccess(PROTOCOL_ACCOUNT, liquidator)
     let liqRes = _executeTransaction(
         "../transactions/flow-alp/pool-management/manual_liquidation.cdc",
         [pid, Type<@MOET.Vault>().identifier, FLOW_TOKEN_IDENTIFIER, 66.0, 50.0],
@@ -1005,6 +1021,7 @@ fun testManualLiquidation_liquidatorOfferWorseThanDex() {
     // Liquidator offers 75 FLOW > 71.43 FLOW (worse price)
     let repayAmount = 50.0
     let seizeAmount = 75.0
+    grantBetaPoolParticipantAccess(PROTOCOL_ACCOUNT, liquidator)
     let liqRes = _executeTransaction(
         "../transactions/flow-alp/pool-management/manual_liquidation.cdc",
         [pid, Type<@MOET.Vault>().identifier, FLOW_TOKEN_IDENTIFIER, seizeAmount, repayAmount],
@@ -1058,6 +1075,7 @@ fun testManualLiquidation_combinedEdgeCase() {
     // But divergence is 9.375% which exceeds 3% threshold
     let repayAmount = 50.0
     let seizeAmount = 75.0
+    grantBetaPoolParticipantAccess(PROTOCOL_ACCOUNT, liquidator)
     let liqRes = _executeTransaction(
         "../transactions/flow-alp/pool-management/manual_liquidation.cdc",
         [pid, Type<@MOET.Vault>().identifier, FLOW_TOKEN_IDENTIFIER, seizeAmount, repayAmount],

--- a/cadence/tests/transactions/flow-alp/pool-management/manual_liquidation_chosen_vault.cdc
+++ b/cadence/tests/transactions/flow-alp/pool-management/manual_liquidation_chosen_vault.cdc
@@ -10,7 +10,7 @@ import "FlowALPv0"
 /// debtVaultIdentifier: e.g., Type<@MOET.Vault>().identifier
 /// seizeVaultIdentifier: e.g., Type<@FlowToken.Vault>().identifier
 transaction(pid: UInt64, purportedDebtVaultIdentifier: String, actualDebtVaultIdentifier: String, seizeVaultIdentifier: String, seizeAmount: UFix64, repayAmount: UFix64) {
-    let pool: &FlowALPv0.Pool
+    let pool: auth(FlowALPv0.EParticipant) &FlowALPv0.Pool
     let receiver: &{FungibleToken.Receiver}
     let actualDebtType: Type
     let purportedDebtType: Type
@@ -18,9 +18,10 @@ transaction(pid: UInt64, purportedDebtVaultIdentifier: String, actualDebtVaultId
     let repay: @{FungibleToken.Vault}
 
     prepare(signer: auth(BorrowValue, SaveValue, IssueStorageCapabilityController, PublishCapability, UnpublishCapability) &Account) {
-        let protocolAddress = Type<@FlowALPv0.Pool>().address!
-        self.pool = getAccount(protocolAddress).capabilities.borrow<&FlowALPv0.Pool>(FlowALPv0.PoolPublicPath)
-            ?? panic("Could not borrow Pool at \(FlowALPv0.PoolPublicPath)")
+        let cap = signer.storage.borrow<&Capability<auth(FlowALPv0.EParticipant, FlowALPv0.EPosition) &FlowALPv0.Pool>>(
+            from: FlowALPv0.PoolCapStoragePath
+        ) ?? panic("Could not borrow Pool capability from storage - ensure the signer has been granted Pool access with EParticipant entitlement")
+        self.pool = cap.borrow() ?? panic("Could not borrow Pool from capability")
 
         // Resolve types
         self.actualDebtType = CompositeType(actualDebtVaultIdentifier) ?? panic("Invalid actualDebtVaultIdentifier: \(actualDebtVaultIdentifier)")

--- a/cadence/transactions/flow-alp/pool-management/manual_liquidation.cdc
+++ b/cadence/transactions/flow-alp/pool-management/manual_liquidation.cdc
@@ -9,16 +9,17 @@ import "FlowALPv0"
 /// debtVaultIdentifier: e.g., Type<@MOET.Vault>().identifier
 /// seizeVaultIdentifier: e.g., Type<@FlowToken.Vault>().identifier
 transaction(pid: UInt64, debtVaultIdentifier: String, seizeVaultIdentifier: String, seizeAmount: UFix64, repayAmount: UFix64) {
-    let pool: &FlowALPv0.Pool
+    let pool: auth(FlowALPv0.EParticipant) &FlowALPv0.Pool
     let receiver: &{FungibleToken.Receiver}
     let debtType: Type
     let seizeType: Type
     let repay: @{FungibleToken.Vault}
 
     prepare(signer: auth(BorrowValue, SaveValue, IssueStorageCapabilityController, PublishCapability, UnpublishCapability) &Account) {
-        let protocolAddress = Type<@FlowALPv0.Pool>().address!
-        self.pool = getAccount(protocolAddress).capabilities.borrow<&FlowALPv0.Pool>(FlowALPv0.PoolPublicPath)
-            ?? panic("Could not borrow Pool at \(FlowALPv0.PoolPublicPath)")
+        let cap = signer.storage.borrow<&Capability<auth(FlowALPv0.EParticipant, FlowALPv0.EPosition) &FlowALPv0.Pool>>(
+            from: FlowALPv0.PoolCapStoragePath
+        ) ?? panic("Could not borrow Pool capability from storage - ensure the signer has been granted Pool access with EParticipant entitlement")
+        self.pool = cap.borrow() ?? panic("Could not borrow Pool from capability")
 
         // Resolve types
         self.debtType = CompositeType(debtVaultIdentifier) ?? panic("Invalid debtVaultIdentifier: \(debtVaultIdentifier)")


### PR DESCRIPTION
## Summary

- Change `manualLiquidation` access from `access(all)` to `access(EParticipant)` so callers must hold an authorized Pool capability
- Update the production `manual_liquidation.cdc` transaction and the test-only `manual_liquidation_chosen_vault.cdc` transaction to borrow the pool via an EParticipant-entitled capability from storage instead of the public path
- Grant the EParticipant cap to liquidator accounts in all 18 liquidation test calls in `liquidation_phase1_test.cdc`

## Test plan

- [x] All 20 liquidation_phase1_test.cdc tests pass
- [x] All 4 cap_test.cdc tests pass

https://claude.ai/code/session_01EScbPupCZD9LkCBWvQDaQ4