### PR TITLE
Deposit capacity limits net instead of gross deposits

### DIFF
--- a/cadence/contracts/FlowALPModels.cdc
+++ b/cadence/contracts/FlowALPModels.cdc
@@ -1176,6 +1176,10 @@ access(all) contract FlowALPModels {
         /// (used when deposits are made)
         access(EImplementation) fun consumeDepositCapacity(_ amount: UFix64, pid: UInt64)
 
+        /// Increases deposit capacity by the specified amount and tracks per-user deposit usage
+        /// (used when withdrawals are made)
+        access(EImplementation) fun refillDepositCapacity(_ amount: UFix64, pid: UInt64)
+
         /// Returns the per-deposit limit based on user deposit limit and available deposit capacity.
         /// Rationale: cap per-deposit size to a fraction of the total depositCapacityCap
         /// so a single large deposit cannot monopolize capacity.
@@ -1514,6 +1518,23 @@ access(all) contract FlowALPModels {
                 remainingCapacity: self.depositCapacity
             )
         }
+
+        /// Increases deposit capacity by the specified amount when a withdrawal is made.
+        /// This is because we want to limit net deposits within a certain time period rather than gross deposits.
+        access(EImplementation) fun refillDepositCapacity(_ amount: UFix64, pid: UInt64) {
+            self.depositCapacity = self.depositCapacity + amount
+            // Track per-user deposit usage
+            let currentUserUsage = self.depositUsage[pid] ?? 0.0
+            self.depositUsage[pid] = currentUserUsage.saturatingSubtract(amount)
+
+            FlowALPEvents.emitDepositCapacityConsumed(
+                tokenType: self.tokenType,
+                pid: pid,
+                amount: 0.0,
+                remainingCapacity: self.depositCapacity
+            )
+        }
+
 
         /// Returns the maximum amount that can be deposited to the given position without being queued.
         access(EImplementation) view fun depositLimit(pid: UInt64): UFix64 {

--- a/cadence/contracts/FlowALPv0.cdc
+++ b/cadence/contracts/FlowALPv0.cdc
@@ -1346,6 +1346,7 @@ access(all) contract FlowALPv0 {
                 )
 
                 let fromReserve <- reserveVault.withdraw(amount: reserveWithdrawAmount)
+                tokenState.refillDepositCapacity(reserveWithdrawAmount, pid: pid)
                 withdrawn.deposit(from: <-fromReserve)
             }
 
@@ -1823,6 +1824,8 @@ access(all) contract FlowALPv0 {
                             amount: uintSinkAmount,
                             tokenState: tokenState
                         )
+                        tokenState.refillDepositCapacity(UFix64(uintSinkAmount), pid: pid)
+
                         let sinkVault <- FlowALPv0._borrowMOETMinter().mintTokens(amount: sinkAmount)
 
                         FlowALPEvents.emitRebalanced(


### PR DESCRIPTION
Closes: #265

## Description

Withdrawing from the token reserve refills the deposit capacity for both the individual position and the token as a whole, so that the deposit capacity tracks net deposits rather than gross deposits.
- Per-position (per-user) deposit limit cannot grow beyond the maximum (depositCapacityCap * fraction)
- Overall token deposit limit can temporarily grow beyond the depositCapacityCap over the regeneration period (one hour) before the limit is reset to the capacity. This means that excess deposit limit generated by withdrawals is regularly reset to the baseline rather than accumulating indefinitely over time (which would allow steady withdrawal followed by sudden large deposit amounts).